### PR TITLE
Restore indent style rule

### DIFF
--- a/base.js
+++ b/base.js
@@ -35,6 +35,7 @@ module.exports = {
     'spaced-comment': ['error', 'always'],
     'keyword-spacing': ['error', { before: true, after: true }],
     'template-curly-spacing': ['error', 'never'],
-    'semi-spacing': 'error'
+    'semi-spacing': 'error',
+    'indent': ['error', 2, { 'SwitchCase': 1 }]
   }
 };


### PR DESCRIPTION
This rule was dropped, I believe unintentionally, in the transition from 1.0.0 -> 1.1.0. 