### PR TITLE
Add curly: error rule to base config

### DIFF
--- a/base.js
+++ b/base.js
@@ -19,7 +19,7 @@ module.exports = {
     'no-console': 'off',
 
     // Code style
-    "curly": "error",
+    'curly': 'error',
     'arrow-parens': ['error', 'always'],
     'array-bracket-spacing': ['error', 'never'],
     'comma-dangle': ['error', 'never'],

--- a/base.js
+++ b/base.js
@@ -19,6 +19,7 @@ module.exports = {
     'no-console': 'off',
 
     // Code style
+    "curly": "error",
     'arrow-parens': ['error', 'always'],
     'array-bracket-spacing': ['error', 'never'],
     'comma-dangle': ['error', 'never'],


### PR DESCRIPTION
context: https://eslint.org/docs/3.0.0/rules/curly

Lots of old node code at Mapbox includes very long single-line if statements, especially around error handling. For example: https://github.com/mapbox/core-maps/blob/master/lib/maps.js#L37. 

However, we've gradually stopped writing in this style, and for good reason: curly braces improve readability and reduce ambiguity in code. Additionally, [prettier](https://prettier.io/), which is increasingly adopted at Mapbox, can turn curly-brace free if statements into very ambiguous multi-line statements, for example (I just spotted this one in real life):

```js
if (
  (typeof config.CoreDBReadRegion !== 'string' ||
    !config.CoreDBReadRegion.length) &&
  (typeof config.CoreDBReadEndpoint !== 'string' ||
    !config.CoreDBReadEndpoint.length)
)
  throw new TypeError(
    'CoreDBReadRegion or CoreDBReadEndpoint must be a string'
  );

/*...*/
```

Therefore, I think we should make the `"curly": "error"` rule an official part of our eslint config.
