### PR TITLE
Add eslint-plugin-inclusive-language at error level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.0.0 (2020-07-09)
+
+- Breaking: Adds eslint-plugin-inclusive-language; will error if uninclusive language is used.
+
 ## 3.0.0 (2020-06-06)
 
 - Breaking: remove support for Node 8.

--- a/base.js
+++ b/base.js
@@ -36,6 +36,8 @@ module.exports = {
     'keyword-spacing': ['error', { before: true, after: true }],
     'template-curly-spacing': ['error', 'never'],
     'semi-spacing': 'error',
-    'indent': ['error', 2, { 'SwitchCase': 1 }]
-  }
+    'indent': ['error', 2, { 'SwitchCase': 1 }],
+    'inclusive-language/use-inclusive-words': 'error'
+  },
+  plugins: ['inclusive-language']
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -314,6 +314,11 @@
         "regexpp": "^3.0.0"
       }
     },
+    "eslint-plugin-inclusive-language": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-inclusive-language/-/eslint-plugin-inclusive-language-1.2.0.tgz",
+      "integrity": "sha512-RNCQNqeMaiUT0nYpVEzdlF2ZTig7cU3C4wdt/6tzkfiD439DYH/QTRvwc73t2aiW5z9U7WntKXo3saTjqTiDYg=="
+    },
     "eslint-plugin-node": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "devDependencies": {
     "eslint": "^7.3.1",
     "eslint-plugin-node": "^11.1.0"
+  },
+  "dependencies": {
+    "eslint-plugin-inclusive-language": "^1.2.0"
   }
 }


### PR DESCRIPTION
This adds `eslint-plugin-inclusive-language` at the error level, so we're notified when we use uninclusive language such as `whitelist` or `blacklist`. Currently this plugin only offers a minimal, basic start, but we can update the package as it grows. https://github.com/muenzpraeger/eslint-plugin-inclusive-language/blob/primary/lib/config/inclusive-words.json.

I'm also targeting this PR at a new branch, `main`, that we can use in lieu of `master`, but I don't have permissions to change the base branch of this repo.

Unsure who should review, so tagging mine own team and devtools.

cc @mapbox/map-design-team @mapbox/developer-tools 