### PR TITLE
eslint-plugin-n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.0.1 (2024-07-01)
+- Replace `eslint-plugin-node` (no longer maintained) with `eslint-plugin-n` 
+
 ## 5.0.0 (2024-03-11)
 - Added `node20` (and relative TypeScript) configuration
 

--- a/node.js
+++ b/node.js
@@ -5,11 +5,11 @@ module.exports = {
   env: {
     node: true
   },
-  plugins: ['node'],
+  plugins: ['n'],
   rules: {
-    'node/no-unsupported-features/es-builtins': ['error'],
-    'node/no-unsupported-features/es-syntax': ['error'],
-    'node/no-unsupported-features/node-builtins': ['error'],
-    'node/no-missing-require': 'error'
+    'n/no-unsupported-features/es-builtins': ['error'],
+    'n/no-unsupported-features/es-syntax': ['error'],
+    'n/no-unsupported-features/node-builtins': ['error'],
+    'n/no-missing-require': 'error'
   }
 };

--- a/node10.js
+++ b/node10.js
@@ -3,8 +3,8 @@
 module.exports = {
   extends: require.resolve('./node'),
   rules: {
-    'node/no-unsupported-features/es-builtins': ['error', { version: '10' }],
-    'node/no-unsupported-features/es-syntax': ['error', { version: '10' }],
-    'node/no-unsupported-features/node-builtins': ['error', { version: '10' }]
+    'n/no-unsupported-features/es-builtins': ['error', { version: '10' }],
+    'n/no-unsupported-features/es-syntax': ['error', { version: '10' }],
+    'n/no-unsupported-features/node-builtins': ['error', { version: '10' }]
   }
 };

--- a/node12.js
+++ b/node12.js
@@ -3,8 +3,8 @@
 module.exports = {
   extends: require.resolve('./node'),
   rules: {
-    'node/no-unsupported-features/es-builtins': ['error', { version: '12' }],
-    'node/no-unsupported-features/es-syntax': ['error', { version: '12' }],
-    'node/no-unsupported-features/node-builtins': ['error', { version: '12' }]
+    'n/no-unsupported-features/es-builtins': ['error', { version: '12' }],
+    'n/no-unsupported-features/es-syntax': ['error', { version: '12' }],
+    'n/no-unsupported-features/node-builtins': ['error', { version: '12' }]
   }
 };

--- a/node14-typescript.js
+++ b/node14-typescript.js
@@ -30,7 +30,7 @@ module.exports = {
           }
         ],
         curly: 'error',
-        'node/no-unsupported-features/es-syntax': 'off',
+        'n/no-unsupported-features/es-syntax': 'off',
         'no-array-constructor': 'off', // must be disabled so the typescript one can take over.
         'no-dupe-keys': 'error',
         'no-extra-semi': 'off', // must be disabled so the typescript one can take over.

--- a/node14.js
+++ b/node14.js
@@ -3,8 +3,8 @@
 module.exports = {
   extends: require.resolve('./node'),
   rules: {
-    'node/no-unsupported-features/es-builtins': ['error', { version: '14' }],
-    'node/no-unsupported-features/es-syntax': ['error', { version: '14' }],
-    'node/no-unsupported-features/node-builtins': ['error', { version: '14' }]
+    'n/no-unsupported-features/es-builtins': ['error', { version: '14' }],
+    'n/no-unsupported-features/es-syntax': ['error', { version: '14' }],
+    'n/no-unsupported-features/node-builtins': ['error', { version: '14' }]
   }
 };

--- a/node20-typescript.js
+++ b/node20-typescript.js
@@ -30,7 +30,7 @@ module.exports = {
           }
         ],
         curly: 'error',
-        'node/no-unsupported-features/es-syntax': 'off',
+        'n/no-unsupported-features/es-syntax': 'off',
         'no-array-constructor': 'off', // must be disabled so the typescript one can take over.
         'no-dupe-keys': 'error',
         'no-extra-semi': 'off', // must be disabled so the typescript one can take over.

--- a/node20.js
+++ b/node20.js
@@ -4,9 +4,9 @@ module.exports = {
   extends: require.resolve('./node'),
   plugins: ['unused-imports'],
   rules: {
-    'node/no-unsupported-features/es-builtins': ['error', { version: '20' }],
-    'node/no-unsupported-features/es-syntax': ['error', { version: '20' }],
-    'node/no-unsupported-features/node-builtins': ['error', { version: '20' }],
+    'n/no-unsupported-features/es-builtins': ['error', { version: '20' }],
+    'n/no-unsupported-features/es-syntax': ['error', { version: '20' }],
+    'n/no-unsupported-features/node-builtins': ['error', { version: '20' }],
     'unused-imports/no-unused-imports': 'error'
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
         "eslint": "^8.57.0",
-        "eslint-plugin-node": "^11.1.0",
+        "eslint-plugin-n": "^17.9.0",
         "eslint-plugin-unused-imports": "^3.1.0"
       }
     },
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
+      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
       "peer": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -647,6 +647,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.17.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
+      "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -714,52 +727,101 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint-plugin-es": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
-      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
       "peer": true,
       "dependencies": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
+        "semver": "^7.5.4"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-17.9.0.tgz",
+      "integrity": "sha512-CPSaXDXdrT4nsrOrO4mT4VB6FMUkoySRkHWuuJJHVqsIEjIeZgMY1H7AzSwPbDScikBmLN82KeM1u7ixV7PzGg==",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "enhanced-resolve": "^5.17.0",
+        "eslint-plugin-es-x": "^7.5.0",
+        "get-tsconfig": "^4.7.0",
+        "globals": "^15.0.0",
+        "ignore": "^5.2.4",
+        "minimatch": "^9.0.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
-        "eslint": ">=4.19.1"
+        "eslint": ">=8.23.0"
       }
     },
-    "node_modules/eslint-plugin-node": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz",
-      "integrity": "sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==",
+    "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "peer": true,
       "dependencies": {
-        "eslint-plugin-es": "^3.0.0",
-        "eslint-utils": "^2.0.0",
-        "ignore": "^5.1.1",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.10.1",
-        "semver": "^6.1.0"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.16.0"
+        "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/eslint-plugin-node/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.7.0.tgz",
+      "integrity": "sha512-ivatRXWwKC6ImcdKO7dOwXuXR5XFrdwo45qFwD7D0qOkEPzzJdLXC3BHceBdyrPOD3p1suPaWi4Y4NMm2D++AQ==",
       "peer": true,
-      "bin": {
-        "semver": "bin/semver.js"
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/eslint-plugin-unused-imports": {
@@ -806,30 +868,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-      "peer": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-      "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -1035,6 +1073,18 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "peer": true
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+      "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+      "peer": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1101,6 +1151,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -1414,12 +1470,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "peer": true
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -1479,30 +1529,6 @@
       ],
       "peer": true
     },
-    "node_modules/regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "peer": true,
-      "dependencies": {
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -1510,6 +1536,15 @@
       "peer": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/reusify": {
@@ -1627,6 +1662,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/eslint-config-mapbox",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Generic eslint configuration for Mapbox",
   "main": "node.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@typescript-eslint/eslint-plugin": "^7.1.1",
     "@typescript-eslint/parser": "^7.1.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^17.9.0",
     "eslint-plugin-unused-imports": "^3.1.0"
   }
 }


### PR DESCRIPTION
This uses eslint-plugin-n instead of eslint-plugin-node, which is no longer actively maintained.

Refs: https://github.com/mapbox/node-pre-gyp/issues/657#issuecomment-2198309930