### PR TITLE
Add new rule for detecting tokens in code

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,3 @@
+singleQuote: true
+trailingComma: 'none'
+arrowParens: 'always'

--- a/base.js
+++ b/base.js
@@ -8,14 +8,15 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2020
   },
+  plugins: ['jsonc', '@mapbox/mapbox'],
   rules: {
     'no-var': 'error',
     'prefer-const': 'error',
-    'eqeqeq': ['error', 'smart'],
+    eqeqeq: ['error', 'smart'],
     'no-confusing-arrow': ['error', { allowParens: false }],
     'no-extend-native': 'error',
     'no-use-before-define': ['error', 'nofunc'],
-    'strict': 'error',
+    strict: 'error',
     'no-console': 'off',
 
     // Code style
@@ -29,13 +30,24 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'object-curly-spacing': ['error', 'always'],
     'prefer-arrow-callback': 'error',
-    'quotes': ['error', 'single', 'avoid-escape'],
-    'semi': ['error', 'always'],
+    quotes: ['error', 'single', 'avoid-escape'],
+    semi: ['error', 'always'],
     'space-infix-ops': 'error',
     'spaced-comment': ['error', 'always'],
     'keyword-spacing': ['error', { before: true, after: true }],
     'template-curly-spacing': ['error', 'never'],
     'semi-spacing': 'error',
-    'indent': ['error', 2, { 'SwitchCase': 1 }]
-  }
+    indent: ['error', 2, { SwitchCase: 1 }],
+    '@mapbox/mapbox/detect-token': 'error'
+  },
+  overrides: [
+    {
+      files: ['*.json', '*.jsonc'],
+      parser: 'jsonc-eslint-parser',
+      rules: {
+        '@mapbox/mapbox/detect-token': 'error',
+        strict: 'off'
+      }
+    }
+  ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,24 @@
 {
   "name": "@mapbox/eslint-config-mapbox",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mapbox/eslint-config-mapbox",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "BSD-2-Clause",
+      "dependencies": {
+        "@mapbox/eslint-plugin-mapbox": "1.0.0"
+      },
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.1.1",
         "@typescript-eslint/parser": "^7.1.1",
         "eslint": "^8.57.0",
+        "eslint-plugin-jsonc": "^2.19.1",
         "eslint-plugin-n": "^17.9.0",
-        "eslint-plugin-unused-imports": "^3.1.0"
+        "eslint-plugin-unused-imports": "^3.1.0",
+        "jsonc-eslint-parser": "^2.4.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -38,18 +43,6 @@
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.0.tgz",
-      "integrity": "sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint-community/regexpp": {
@@ -125,6 +118,19 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "peer": true
+    },
+    "node_modules/@mapbox/eslint-plugin-mapbox": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/eslint-plugin-mapbox/-/eslint-plugin-mapbox-1.0.0.tgz",
+      "integrity": "sha512-b3tzRdvIFxhO83VXu8TagZxn6dIwDMJSCS0L3k2ciK8haoZxHPaUnJstrxcebM70w+ID8UvlZz7Stf+blJWPBQ==",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": ">=7.1.1",
+        "@typescript-eslint/parser": ">=7.1.1",
+        "eslint": ">=8.57.0",
+        "eslint-plugin-jsonc": ">=2.19.1",
+        "eslint-plugin-unused-imports": ">=3.1.0",
+        "jsonc-eslint-parser": ">=2.4.0"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -391,18 +397,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -742,6 +736,27 @@
         "eslint": ">=6.0.0"
       }
     },
+    "node_modules/eslint-json-compat-utils": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-json-compat-utils/-/eslint-json-compat-utils-0.2.1.tgz",
+      "integrity": "sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==",
+      "peer": true,
+      "dependencies": {
+        "esquery": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "jsonc-eslint-parser": "^2.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@eslint/json": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-es-x": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
@@ -761,6 +776,46 @@
       },
       "peerDependencies": {
         "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc": {
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsonc/-/eslint-plugin-jsonc-2.19.1.tgz",
+      "integrity": "sha512-MmlAOaZK1+Lg7YoCZPGRjb88ZjT+ct/KTsvcsbZdBm+w8WMzGx+XEmexk0m40P1WV9G2rFV7X3klyRGRpFXEjA==",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "eslint-compat-utils": "^0.6.0",
+        "eslint-json-compat-utils": "^0.2.1",
+        "espree": "^9.6.1",
+        "graphemer": "^1.4.0",
+        "jsonc-eslint-parser": "^2.0.4",
+        "natural-compare": "^1.4.0",
+        "synckit": "^0.6.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsonc/node_modules/eslint-compat-utils": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.4.tgz",
+      "integrity": "sha512-/u+GQt8NMfXO8w17QendT4gvO5acfxQsAKirAt0LVxDnr2N8YLCVbregaNc/Yhp7NM128DwCaRvr8PLDfeNkQw==",
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-plugin-n": {
@@ -870,7 +925,7 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
@@ -899,22 +954,10 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "peer": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
       "peer": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -1282,6 +1325,24 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "peer": true
+    },
+    "node_modules/jsonc-eslint-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonc-eslint-parser/-/jsonc-eslint-parser-2.4.0.tgz",
+      "integrity": "sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.5.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -1664,6 +1725,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.6.2.tgz",
+      "integrity": "sha512-Vhf+bUa//YSTYKseDiiEuQmhGCoIF3CVBhunm3r/DQnYiGT4JssmnKQc44BIyOZRK2pKjXXAgbhfmbeoC9CJpA==",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
     "node_modules/tapable": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -1702,6 +1775,12 @@
       "peerDependencies": {
         "typescript": ">=4.2.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1787,6 +1866,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "plugins/eslint-plugin-detect-token": {
+      "version": "1.0.0",
+      "extraneous": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mapbox/eslint-config-mapbox",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "description": "Generic eslint configuration for Mapbox",
   "main": "node.js",
   "repository": {
@@ -22,6 +22,11 @@
     "@typescript-eslint/parser": "^7.1.1",
     "eslint": "^8.57.0",
     "eslint-plugin-n": "^17.9.0",
-    "eslint-plugin-unused-imports": "^3.1.0"
+    "eslint-plugin-unused-imports": "^3.1.0",
+    "eslint-plugin-jsonc": "^2.19.1",
+    "jsonc-eslint-parser": "^2.4.0"
+  },
+  "dependencies": {
+    "@mapbox/eslint-plugin-mapbox": "1.0.0"
   }
 }


### PR DESCRIPTION
Add @mapbox/eslint-plugin-mapbox plugin to eslint that detects potentially valid tokens in js, ts, jsx, tsx and json files. 

Example of the rule in api-styles:
![image](https://github.com/user-attachments/assets/615f6ce6-f2c2-4a60-8c91-f92ade838ef6)

[Repo for @mapbox/eslint-plugin-mapbox package ](https://github.com/mapbox/eslint-plugin-mapbox)